### PR TITLE
Bump postgresql version driver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val unfiltered = Seq(
 
 val sql = Seq(
   "org.flywaydb"          %  "flyway-core"              % "3.2.1",
-  "org.postgresql"        %  "postgresql"               % "9.4-1206-jdbc42",
+  "org.postgresql"        %  "postgresql"               % "9.4.1208.jre7",
   "com.typesafe.slick"    %% "slick"                    % "3.1.0",
   "com.zaxxer"            %  "HikariCP"                 % "2.4.1",
   "com.github.tototoshi"  %% "slick-joda-mapper"        % "2.1.0"


### PR DESCRIPTION
Cant't get the old one to work with postgresql-9.5.2(latest) Don't know if it work with the current version in test og prod, so should probably be testet before merging.